### PR TITLE
fix installation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
+include README.md
 include versioneer.py
 include pyunicore/_version.py


### PR DESCRIPTION
when installing pyunicore in a virtualenv with pip I get:
(venv) courcol@bluebrain224:test/ (fix_install) $ pip install pyunicore                                                                                                                                 [13:19:31]
Collecting pyunicore
  Using cached pyunicore-0.1.1.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-2ncHmv/pyunicore/setup.py", line 7, in <module>
        long_description = open("README.md").read()
    IOError: [Errno 2] No such file or directory: 'README.md'
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-2ncHmv/pyunicore/

The purpose of this pull request is to fix this issue of missing README.md
