### PR TITLE
Add basic docs for CWL converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ inputs:
 outputs: []
 ```
 
-```
+```yaml
 # hello_world.yml
 
 message: "Hello World"

--- a/README.md
+++ b/README.md
@@ -223,6 +223,41 @@ dask_client = Client(uc_cluster, timeout=120)
 That's it! Now Dask will run its computations using the scheduler
 and workers started via UNICORE on the HPC site.
 
+### Convert a CWL job to UNICORE
+
+PyUNICORE provides a tool to convert a CWL CommanLineTool and input into a
+UNICORE job file. Given the following YAML files that describe a
+CommandLineTool wrapper for the echo command and an input file:
+
+```yaml
+# echo.cwl
+
+cwlVersion: v1.2
+
+class: CommandLineTool
+baseCommand: echo
+
+inputs:
+  message:
+    type: string
+    inputBinding:
+      position: 1
+
+outputs: []
+```
+
+```
+# hello_world.yml
+
+message: "Hello World"
+```
+
+A UNICORE job file can be generated using the following command:
+
+```bash
+unicore-cwl-runner echo.cwl hello_world.yml > hello_world.u
+```
+
 ## Helpers
 
 The `pyunicore.helpers` module provides a set of higher-level APIs:

--- a/pyunicore/cwltool.py
+++ b/pyunicore/cwltool.py
@@ -25,7 +25,7 @@ def read_cwl_files(cwl_doc_path, cwl_inputs_object_path=None, debug=False):
     return cwl_doc, cwl_inputs_object
 
 
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "cwl_document",
@@ -55,3 +55,7 @@ if __name__ == "__main__":
     print(json.dumps(unicore_job, indent=2, sort_keys=True))
 
     sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Hi,

I fixed the `unicore-cwl-runner` script (main method was missing) and added some basic docs for the CWL converter. We wanted to have something that can be linked to from the HELIPORT deliverables website.

Please let me know what you think!

Thanks!