### PR TITLE
Add .stop_forwarding function to Forwarder class

### DIFF
--- a/pyunicore/forwarder.py
+++ b/pyunicore/forwarder.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse
 from pyunicore.client import Transport
 from pyunicore.credentials import create_credential
 
+
 class Forwarder:
     """Forwarding helper"""
 

--- a/pyunicore/forwarder.py
+++ b/pyunicore/forwarder.py
@@ -101,8 +101,12 @@ class Forwarder:
 
     def start_forwarding(self):
         self.quiet or print("Start forwarding.")
-        threading.Thread(target=self.transfer, args=(self.client_socket, self.service_socket)).start()
-        threading.Thread(target=self.transfer, args=(self.service_socket, self.client_socket)).start()
+        threading.Thread(
+            target=self.transfer, args=(self.client_socket, self.service_socket)
+        ).start()
+        threading.Thread(
+            target=self.transfer, args=(self.service_socket, self.client_socket)
+        ).start()
 
     def stop_forwarding(self):
         try:


### PR DESCRIPTION
`service_socket` and `client_socket` should be stored in the class object. This enables us to use the `Forwarder` class in a larger, long-running python program. Port forwarding can be started and stopped, without the need of restarting the long-running python process.


Example usage with async:
```
import asyncio

from pyunicore.forwarder import Forwarder

class MyLongRunningService:
...
    async def start_forward(self):
        unicore_job = self.get_job()
        port = self.get_service_port()
        address = self.get_service_address()

        def run_forward():
            endpoint = unicore_job.links["forwarding"]
            tr = unicore_job.transport._clone()
            tr.use_security_sessions = False
            self.forwarder = Forwarder(tr, endpoint, service_port=int(port), service_host=address)
            self.forwarder.run(self.port)

        loop = asyncio.get_running_loop()
        self.unicore_forwarder = loop.run_in_executor(None, run_forward)


    async def stop_forward(self):
        unicore_forwarder = getattr(self, 'unicore_forwarder', None)
        if unicore_forwarder:
            try:
                unicore_forwarder.cancel()
                await unicore_forwarder
            except asyncio.CancelledError:
                pass
        forwarder = getattr(self, 'forwarder', None)
        if forwarder:
            forwarder.stop_forwarding()
```

